### PR TITLE
Update all raw urls to the new github raw subdomain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A basic structure for ruby gems. To setup a new project, run:
     mkdir myproject
     cd myproject
 
-    curl -sLS https://github.com/rcarver/gembase/raw/master/init.sh | sh
+    curl -sLS https://raw.github.com/rcarver/gembase/master/init.sh | sh
 
 You can also use this to convert an existing project. The script will
 overwrite any existing files, but git will show you the diff.
@@ -53,7 +53,7 @@ If you don't want gembase to bootstrap your entire project
 but would like to use its conventions rake tasks, just grab
 Rakefile.base and load it up.
 
-    curl -sO https://github.com/rcarver/gembase/raw/master/Rakefile.base
+    curl -sO https://raw.github.com/rcarver/gembase/master/Rakefile.base
 
 # About
 

--- a/Rakefile.base
+++ b/Rakefile.base
@@ -37,5 +37,5 @@ task :default => :test
 
 desc "Update Rakefile.base"
 task :selfupdate do
-  sh "curl -sO https://github.com/rcarver/gembase/raw/master/Rakefile.base"
+  sh "curl -sO https://raw.github.com/rcarver/gembase/master/Rakefile.base"
 end

--- a/init.sh
+++ b/init.sh
@@ -8,14 +8,14 @@ echo 'Creating Rakefile'
 if [ "$RAKETEMPLATE" != "" ]; then
   cp $RAKETEMPLATE Rakefile
 else
-  curl -s "https://github.com/rcarver/gembase/raw/master/Rakefile.template" > Rakefile
+  curl -s "https://raw.github.com/rcarver/gembase/master/Rakefile.template" > Rakefile
 fi
 
 echo 'Creating Rakefile.base'
 if [ "$RAKEBASE" != "" ]; then
   cp $RAKEBASE .
 else
-  curl -sO "https://github.com/rcarver/gembase/raw/master/Rakefile.base"
+  curl -sO "https://raw.github.com/rcarver/gembase/master/Rakefile.base"
 fi
 
 echo 'Creating CHANGELOG.md'


### PR DESCRIPTION
So github now uses raw.github.com for all raw file requests. This pull request includes all the required changes so that gembase will continue to function.

Long live raw.github.com.
